### PR TITLE
fix resource leak

### DIFF
--- a/dex-lib/src/main/java/com/baidu/titan/dexlib/dex/Dex.java
+++ b/dex-lib/src/main/java/com/baidu/titan/dexlib/dex/Dex.java
@@ -99,16 +99,18 @@ public final class Dex {
      */
     public Dex(File file) throws IOException {
         if (FileUtils.hasArchiveSuffix(file.getName())) {
-            ZipFile zipFile = new ZipFile(file);
-            ZipEntry entry = zipFile.getEntry(DexFormat.DEX_IN_JAR_NAME);
-            if (entry != null) {
-                loadFrom(zipFile.getInputStream(entry));
-                zipFile.close();
-            } else {
-                throw new DexException("Expected " + DexFormat.DEX_IN_JAR_NAME + " in " + file);
+            try (ZipFile zipFile = new ZipFile(file)) {
+                ZipEntry entry = zipFile.getEntry(DexFormat.DEX_IN_JAR_NAME);
+                if (entry != null) {
+                    loadFrom(zipFile.getInputStream(entry));
+                } else {
+                    throw new DexException("Expected " + DexFormat.DEX_IN_JAR_NAME + " in " + file);
+                }
             }
         } else if (file.getName().endsWith(".dex")) {
-            loadFrom(new FileInputStream(file));
+            try (InputStream in = new FileInputStream(file)) {
+                loadFrom(in);
+            }
         } else {
             throw new DexException("unknown output extension: " + file);
         }
@@ -147,7 +149,6 @@ public final class Dex {
         while ((count = in.read(buffer)) != -1) {
             bytesOut.write(buffer, 0, count);
         }
-        in.close();
 
         this.data = ByteBuffer.wrap(bytesOut.toByteArray());
         this.data.order(ByteOrder.LITTLE_ENDIAN);


### PR DESCRIPTION
Using `try-with-resource` to replace invoke `close` method, which may lead to `ZipFile` leak in line 108
https://github.com/baidu/titan-dex/blob/370682cdec282a68f4c68092c8171a2960ac2f6c/dex-lib/src/main/java/com/baidu/titan/dexlib/dex/Dex.java#L104-L109

And then, `ZipFile.close` also close the `InputStream` object, which is the return value for `ZipEntry.getInputStream`. No need to call `InputStream.close`.

Finally, remove `InputStream.close` which be called in `loadFrom`, the lifetime of the parameters should be guaranteed by the caller.